### PR TITLE
Example is not working. so I modified it.

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp.router(
       title: 'TurnPageTransition Example',
       debugShowCheckedModeBanner: false,
+      routerConfig: routes,
       theme: ThemeData(
         pageTransitionsTheme: const TurnPageTransitionsTheme(
           overleafColor: Colors.grey,
@@ -23,8 +24,8 @@ class MyApp extends StatelessWidget {
         ),
         primarySwatch: Colors.blue,
       ),
-      routeInformationParser: routes.routeInformationParser,
-      routerDelegate: routes.routerDelegate,
+      // routeInformationParser: routes.routeInformationParser,
+      // routerDelegate: routes.routerDelegate,
     );
   }
 }

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -15,7 +15,7 @@ class Routes {
   static GoRouter routes({String? initialLocation}) {
     return GoRouter(
       initialLocation: initialLocation ?? home,
-      redirect: (state) => null,
+      // redirect: (context, state) => null,
       routes: [
         GoRoute(
           path: home,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  go_router: ^3.1.1
+  go_router: ^14.2.7
   turn_page_transition:
     path: ../
 


### PR DESCRIPTION
1. Changed Android kotlin minium support version.(1.6.10 → 1.7.10)
<p> 
> Kotlin version (1.6.10) is lower than Flutter's minimum supported version of 1.7.0. Please upgrade your Kotlin version. <br/>
> Kotlin version (1.7.0) will soon be dropped. Please upgrade your Kotlin version to a version of at least 1.7.10 soon. </p>

2. Changed go_router library (^3.1.1 → ^14.2.7)
<p> 
>  Error: The class 'NavigatorObserver' can't be used as a mixin because it isn't a mixin class nor a mixin. <br/>
+ Input routes into 'routerConfig' parameter in MaterialApp.router.</p>