### PR TITLE
feat: #10 add top bottom direction

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       routerConfig: routes,
       theme: ThemeData(
-        pageTransitionsTheme: const TurnPageTransitionsTheme(
+        pageTransitionsTheme: TurnPageTransitionsTheme(
           overleafColor: Colors.grey,
           animationTransitionPoint: 0.5,
         ),

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -39,7 +39,7 @@ class Routes {
               animation: animation,
               overleafColor: Colors.blueAccent,
               animationTransitionPoint: 0.5,
-              direction: TurnDirection.rightToLeft,
+              startCorner: TurnCorner.bottomRight,
               child: child,
             ),
           ),

--- a/example/lib/ui/page_view_page.dart
+++ b/example/lib/ui/page_view_page.dart
@@ -16,7 +16,7 @@ class PageViewPage extends StatelessWidget {
         return _Page(index: index, color: color);
       },
     );
-    final controller = TurnPageController();
+    final controller = TurnPageController(startCorner: TurnCorner.bottomRight);
     return Scaffold(
       body: TurnPageView.builder(
         controller: controller,

--- a/lib/src/turn_corner.dart
+++ b/lib/src/turn_corner.dart
@@ -1,0 +1,13 @@
+/// The corner to turn.
+enum TurnCorner {
+  topRight,
+  topLeft,
+  bottomRight,
+  bottomLeft;
+
+  /// Returns true if this corner is at the right of the screen
+  get isRight => this == TurnCorner.bottomRight || this == TurnCorner.topRight;
+
+  /// Returns true if this corner is at the top of the screen
+  get isTop => this == TurnCorner.topLeft || this == TurnCorner.topRight;
+}

--- a/lib/src/turn_direction.dart
+++ b/lib/src/turn_direction.dart
@@ -1,5 +1,16 @@
+import 'package:turn_page_transition/src/turn_corner.dart';
+
 /// The direction in which the pages are turned.
 enum TurnDirection {
   rightToLeft,
-  leftToRight,
+  leftToRight;
+
+  TurnCorner toTurnCorner() {
+    switch (this) {
+      case TurnDirection.rightToLeft:
+        return TurnCorner.topRight;
+      case TurnDirection.leftToRight:
+        return TurnCorner.topLeft;
+    }
+  }
 }

--- a/lib/src/turn_page_animation.dart
+++ b/lib/src/turn_page_animation.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:turn_page_transition/src/const.dart';
+import 'package:turn_page_transition/src/turn_corner.dart';
 import 'package:turn_page_transition/src/turn_direction.dart';
 
 /// A widget that provides a page-turning animation.
@@ -9,9 +10,11 @@ class TurnPageAnimation extends StatelessWidget {
     required this.animation,
     required this.overleafColor,
     this.animationTransitionPoint,
+    @Deprecated("Use turnCorner instead")
     this.direction = TurnDirection.rightToLeft,
+    TurnCorner? startCorner,
     required this.child,
-  }) {
+  }) : startCorner = startCorner ?? direction.toTurnCorner() {
     final transitionPoint = animationTransitionPoint;
     assert(
       transitionPoint == null || 0 <= transitionPoint && transitionPoint < 1,
@@ -30,8 +33,11 @@ class TurnPageAnimation extends StatelessWidget {
   /// This value must be 0 <= animationTransitionPoint < 1.
   final double? animationTransitionPoint;
 
-  /// The direction in which the pages are turned.
+  @Deprecated("Use [turnCorner] instead")
   final TurnDirection direction;
+
+  /// The corner where the turn should start
+  final TurnCorner startCorner;
 
   /// The widget that is displayed with the page-turning animation.
   final Widget child;
@@ -41,16 +47,15 @@ class TurnPageAnimation extends StatelessWidget {
     final transitionPoint =
         this.animationTransitionPoint ?? defaultAnimationTransitionPoint;
 
-    final alignment = direction == TurnDirection.rightToLeft
-        ? Alignment.centerLeft
-        : Alignment.centerRight;
+    final alignment =
+        startCorner.isRight ? Alignment.centerLeft : Alignment.centerRight;
 
     return CustomPaint(
       foregroundPainter: _OverleafPainter(
         animation: animation,
         color: overleafColor,
         animationTransitionPoint: transitionPoint,
-        direction: direction,
+        startCorner: startCorner,
       ),
       child: Align(
         alignment: alignment,
@@ -58,7 +63,7 @@ class TurnPageAnimation extends StatelessWidget {
           clipper: _PageTurnClipper(
             animation: animation,
             animationTransitionPoint: transitionPoint,
-            direction: direction,
+            startCorner: startCorner,
           ),
           child: Align(
             alignment: alignment,
@@ -75,7 +80,7 @@ class _PageTurnClipper extends CustomClipper<Path> {
   const _PageTurnClipper({
     required this.animation,
     required this.animationTransitionPoint,
-    this.direction = TurnDirection.leftToRight,
+    required this.startCorner,
   });
 
   /// The animation that controls the page-turning effect.
@@ -85,8 +90,8 @@ class _PageTurnClipper extends CustomClipper<Path> {
   /// This value must be between 0 and 1 (0 <= animationTransitionPoint < 1).
   final double animationTransitionPoint;
 
-  /// The direction in which the pages are turned.
-  final TurnDirection direction;
+  /// The corner where the turn should start
+  final TurnCorner startCorner;
 
   /// Creates the clipping path based on the animation progress and direction.
   @override
@@ -98,49 +103,57 @@ class _PageTurnClipper extends CustomClipper<Path> {
     final verticalVelocity = 1 / animationTransitionPoint;
 
     late final double innerTopCornerX;
+    late final double innerTopCornerY;
     late final double innerBottomCornerX;
+    late final double innerBottomCornerY;
     late final double outerBottomCornerX;
+    late final double outerBottomCornerY;
     late final double foldUpperCornerX;
+    late final double foldUpperCornerY;
     late final double foldLowerCornerX;
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        innerTopCornerX = 0.0;
-        innerBottomCornerX = 0.0;
-        foldUpperCornerX = width * (1.0 - animationProgress);
-        break;
-      case TurnDirection.leftToRight:
-        innerTopCornerX = width;
-        innerBottomCornerX = width;
-        foldUpperCornerX = width * animationProgress;
-        break;
+    late final double foldLowerCornerY;
+    if (startCorner.isRight) {
+      innerTopCornerX = 0.0;
+      innerBottomCornerX = 0.0;
+      foldUpperCornerX = width * (1.0 - animationProgress);
+    } else {
+      innerTopCornerX = width;
+      innerBottomCornerX = width;
+      foldUpperCornerX = width * animationProgress;
+    }
+    if (startCorner.isTop) {
+      innerTopCornerY = 0;
+      innerBottomCornerY = height;
+      foldUpperCornerY = 0;
+    } else {
+      innerTopCornerY = 0;
+      innerBottomCornerY = 0;
+      foldUpperCornerY = 0;
     }
 
-    final innerTopCorner = Offset(innerTopCornerX, 0.0);
-    final foldUpperCorner = Offset(foldUpperCornerX, 0.0);
-    final innerBottomCorner = Offset(innerBottomCornerX, height);
-
     final path = Path()
-      ..moveTo(innerTopCorner.dx, innerTopCorner.dy)
-      ..lineTo(foldUpperCorner.dx, foldUpperCorner.dy);
+      ..moveTo(innerTopCornerX, innerTopCornerY)
+      ..lineTo(foldUpperCornerX, foldUpperCornerY);
 
     if (animationProgress <= animationTransitionPoint) {
-      final foldLowerCornerY = height * verticalVelocity * animationProgress;
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          outerBottomCornerX = width;
-          foldLowerCornerX = width;
-          break;
-        case TurnDirection.leftToRight:
-          outerBottomCornerX = 0.0;
-          foldLowerCornerX = 0.0;
-          break;
+      if (startCorner.isRight) {
+        outerBottomCornerX = width;
+        foldLowerCornerX = width;
+      } else {
+        outerBottomCornerX = 0.0;
+        foldLowerCornerX = 0.0;
       }
-      final outerBottomCorner = Offset(outerBottomCornerX, height);
-      final foldLowerCorner = Offset(foldLowerCornerX, foldLowerCornerY);
+      if (startCorner.isTop) {
+        foldLowerCornerY = height * verticalVelocity * animationProgress;
+        outerBottomCornerY = height;
+      } else {
+        foldLowerCornerY = 0;
+        outerBottomCornerY = 0;
+      }
       path
-        ..lineTo(foldLowerCorner.dx, foldLowerCorner.dy)
-        ..lineTo(outerBottomCorner.dx, outerBottomCorner.dy)
-        ..lineTo(innerBottomCorner.dx, innerBottomCorner.dy)
+        ..lineTo(foldLowerCornerX, foldLowerCornerY)
+        ..lineTo(outerBottomCornerX, outerBottomCornerY)
+        ..lineTo(innerBottomCornerX, innerBottomCornerY)
         ..close();
     } else {
       final progressSubtractedDefault =
@@ -149,20 +162,20 @@ class _PageTurnClipper extends CustomClipper<Path> {
       final turnedBottomWidth =
           width * progressSubtractedDefault * horizontalVelocity;
 
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          foldLowerCornerX = width - turnedBottomWidth;
-          break;
-        case TurnDirection.leftToRight:
-          foldLowerCornerX = turnedBottomWidth;
-          break;
+      if (startCorner.isRight) {
+        foldLowerCornerX = width - turnedBottomWidth;
+      } else {
+        foldLowerCornerX = turnedBottomWidth;
+      }
+      if (startCorner.isTop) {
+        foldLowerCornerY = height;
+      } else {
+        foldLowerCornerY = 0;
       }
 
-      final foldLowerCorner = Offset(foldLowerCornerX, height);
-
       path
-        ..lineTo(foldLowerCorner.dx, foldLowerCorner.dy) // BottomLeft
-        ..lineTo(innerBottomCorner.dx, innerBottomCorner.dy) // BottomRight
+        ..lineTo(foldLowerCornerX, foldLowerCornerY) // BottomLeft
+        ..lineTo(innerBottomCornerX, innerBottomCornerY) // BottomRight
         ..close();
     }
 
@@ -181,7 +194,7 @@ class _OverleafPainter extends CustomPainter {
     required this.animation,
     required this.color,
     required this.animationTransitionPoint,
-    required this.direction,
+    required this.startCorner,
   });
 
   /// The animation that controls the page-turning effect.
@@ -194,8 +207,8 @@ class _OverleafPainter extends CustomPainter {
   /// This value must be between 0 and 1 (0 <= animationTransitionPoint < 1).
   final double animationTransitionPoint;
 
-  /// The direction in which the pages are turned.
-  final TurnDirection direction;
+  /// The corner where the turn should start
+  final TurnCorner startCorner;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -203,24 +216,29 @@ class _OverleafPainter extends CustomPainter {
     final height = size.height;
     final animationProgress = animation.value;
 
-    late final double topCornerX;
-    late final double bottomCornerX;
+    late final double startCornerX;
+    late final double startCornerY;
+    late final double endCornerX;
+    late final double endCornerY;
     late final double topFoldX;
+    late final double topFoldY;
     late final double bottomFoldX;
+    late final double bottomFoldY;
 
     final turnedXDistance = width * animationProgress;
 
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        topFoldX = width - turnedXDistance;
-        break;
-      case TurnDirection.leftToRight:
-        topFoldX = turnedXDistance;
-        break;
+    if (startCorner.isRight) {
+      topFoldX = width - turnedXDistance;
+    } else {
+      topFoldX = turnedXDistance;
     }
-    final topFold = Offset(topFoldX, 0.0);
+    if (startCorner.isTop) {
+      topFoldY = 0;
+    } else {
+      topFoldY = height;
+    }
 
-    final path = Path()..moveTo(topFold.dx, topFold.dy);
+    final path = Path()..moveTo(topFoldX, topFoldY);
 
     if (animationProgress <= animationTransitionPoint) {
       final verticalVelocity = 1 / animationTransitionPoint;
@@ -232,22 +250,24 @@ class _OverleafPainter extends CustomPainter {
       final intersectionX = (W * H * H) / (W * W + H * H);
       final intersectionY = (W * W * H) / (W * W + H * H);
 
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          topCornerX = width - 2 * intersectionX;
-          bottomFoldX = width;
-          break;
-        case TurnDirection.leftToRight:
-          topCornerX = 2 * intersectionX;
-          bottomFoldX = 0.0;
-          break;
+      if (startCorner.isRight) {
+        startCornerX = width - 2 * intersectionX;
+        bottomFoldX = width;
+      } else {
+        startCornerX = 2 * intersectionX;
+        bottomFoldX = 0.0;
       }
-      final topCorner = Offset(topCornerX, 2 * intersectionY);
-      final bottomFold = Offset(bottomFoldX, turnedYDistance);
+      if (startCorner.isTop) {
+        startCornerY = 2 * intersectionY;
+        bottomFoldY = turnedYDistance;
+      } else {
+        startCornerY = height - 2 * intersectionY;
+        bottomFoldY = height + turnedYDistance;
+      }
 
       path
-        ..lineTo(topCorner.dx, topCorner.dy)
-        ..lineTo(bottomFold.dx, bottomFold.dy)
+        ..lineTo(startCornerX, startCornerY)
+        ..lineTo(bottomFoldX, bottomFoldY)
         ..close();
     } else if (animationProgress < 1) {
       final horizontalVelocity = 1 / (1 - animationTransitionPoint);
@@ -275,29 +295,29 @@ class _OverleafPainter extends CustomPainter {
       final turnedBottomWidth =
           width * progressSubtractedDefault * horizontalVelocity;
 
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          topCornerX = width - 2 * intersectionX;
-          bottomCornerX = width - 2 * intersectionX * intersectionCorrection;
-          bottomFoldX = width - turnedBottomWidth;
-          break;
-        case TurnDirection.leftToRight:
-          topCornerX = 2 * intersectionX;
-          bottomCornerX = 2 * intersectionX * intersectionCorrection;
-          bottomFoldX = turnedBottomWidth;
-          break;
+      if (startCorner.isRight) {
+        startCornerX = width - 2 * intersectionX;
+        endCornerX = width - 2 * intersectionX * intersectionCorrection;
+        bottomFoldX = width - turnedBottomWidth;
+      } else {
+        startCornerX = 2 * intersectionX;
+        endCornerX = 2 * intersectionX * intersectionCorrection;
+        bottomFoldX = turnedBottomWidth;
       }
-      final topCorner = Offset(topCornerX, 2 * intersectionY);
-      final bottomCorner = Offset(
-        bottomCornerX,
-        2 * intersectionY * intersectionCorrection + height,
-      );
-      final bottomFold = Offset(bottomFoldX, height);
+      if (startCorner.isTop) {
+        startCornerY = 2 * intersectionY;
+        endCornerY = 2 * intersectionY * intersectionCorrection + height;
+        bottomFoldY = height;
+      } else {
+        startCornerY = 0;
+        endCornerY = 2 * intersectionY * intersectionCorrection;
+        bottomFoldY = 0;
+      }
 
       path
-        ..lineTo(topCorner.dx, topCorner.dy)
-        ..lineTo(bottomCorner.dx, bottomCorner.dy)
-        ..lineTo(bottomFold.dx, bottomFold.dy)
+        ..lineTo(startCornerX, startCornerY)
+        ..lineTo(endCornerX, endCornerY)
+        ..lineTo(bottomFoldX, bottomFoldY)
         ..close();
     } else {
       path.reset();

--- a/lib/src/turn_page_route.dart
+++ b/lib/src/turn_page_route.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:turn_page_transition/src/const.dart';
+import 'package:turn_page_transition/src/turn_corner.dart';
 import 'package:turn_page_transition/src/turn_direction.dart';
 import 'package:turn_page_transition/src/turn_page_transition.dart';
 
@@ -22,7 +23,9 @@ class TurnPageRoute<T> extends PageRoute<T> {
     this.overleafColor = defaultOverleafColor,
     @Deprecated('Use animationTransitionPoint instead') this.turningPoint,
     this.animationTransitionPoint,
+    @Deprecated("Use turnCorner instead")
     this.direction = TurnDirection.rightToLeft,
+    TurnCorner? startCorner,
     this.transitionDuration = defaultTransitionDuration,
     this.reverseTransitionDuration = defaultTransitionDuration,
     this.opaque = true,
@@ -31,7 +34,7 @@ class TurnPageRoute<T> extends PageRoute<T> {
     this.barrierLabel,
     this.maintainState = true,
     bool fullscreenDialog = false,
-  });
+  }) : startCorner = startCorner ?? direction.toTurnCorner();
 
   /// The builder function to create the target widget.
   final WidgetBuilder builder;
@@ -47,8 +50,11 @@ class TurnPageRoute<T> extends PageRoute<T> {
   /// This value must be 0 <= animationTransitionPoint < 1.
   final double? animationTransitionPoint;
 
-  /// The direction in which the pages are turned.
+  @Deprecated("Use turnCorner instead")
   final TurnDirection direction;
+
+  /// The corner where the turn should start
+  final TurnCorner startCorner;
 
   @override
   final Duration transitionDuration;
@@ -93,7 +99,7 @@ class TurnPageRoute<T> extends PageRoute<T> {
       animation: animation,
       overleafColor: overleafColor,
       animationTransitionPoint: transitionPoint,
-      direction: direction,
+      startCorner: startCorner,
       child: child,
     );
   }

--- a/lib/src/turn_page_transition_calc.dart
+++ b/lib/src/turn_page_transition_calc.dart
@@ -1,75 +1,104 @@
 import 'package:flutter/material.dart';
-import 'package:turn_page_transition/src/turn_direction.dart';
+import 'package:turn_page_transition/src/turn_corner.dart';
 
 class PageTurnClipperCalculator {
-  Offset calcTopCorner({
+  Offset calcCornerToFold({
     required double childWidth,
-    required TurnDirection direction,
+    required double childHeight,
+    required TurnCorner turnCorner,
   }) {
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        return Offset(childWidth, 0);
-      case TurnDirection.leftToRight:
-        return Offset(0, 0);
+    late final double dx;
+    late final double dy;
+    if (turnCorner.isRight) {
+      dx = childWidth;
+    } else {
+      dx = 0;
     }
+    if (turnCorner.isTop) {
+      dy = 0;
+    } else {
+      dy = childHeight;
+    }
+    return Offset(dx, dy);
   }
 
-  Offset calcBottomCorner({
+  Offset calcOppositeCornerToFold({
     required double childWidth,
-    required double height,
-    required TurnDirection direction,
+    required double childHeight,
+    required TurnCorner turnCorner,
     required double animationTransitionPoint,
     required double animationProgress,
   }) {
     if (animationProgress > animationTransitionPoint) {
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          return Offset(childWidth, height);
-        case TurnDirection.leftToRight:
-          return Offset(0, height);
+      late final double dx;
+      late final double dy;
+      if (turnCorner.isRight) {
+        dx = childWidth;
+      } else {
+        dx = 0;
       }
+      if (turnCorner.isTop) {
+        dy = childHeight;
+      } else {
+        dy = 0;
+      }
+      return Offset(dx, dy);
     }
 
     // `animationProgress`の最大を`animationTransitionPoint`として、
     // めくられたページの高さの割合
     final turnedPageHeightRatio = animationProgress / animationTransitionPoint;
-    final bottomCornerY = height * turnedPageHeightRatio;
 
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        return Offset(childWidth, bottomCornerY);
-      case TurnDirection.leftToRight:
-        return Offset(0, bottomCornerY);
+    late final double dx;
+    late final double dy;
+    if (turnCorner.isRight) {
+      dx = childWidth;
+    } else {
+      dx = 0;
     }
+    if (turnCorner.isTop) {
+      dy = childHeight * turnedPageHeightRatio;
+    } else {
+      dy = childHeight - childHeight * turnedPageHeightRatio;
+    }
+    return Offset(dx, dy);
   }
 
   Offset calcFoldUpperCorner({
     required double childWidth,
-    required TurnDirection direction,
+    required double childHeight,
+    required TurnCorner turnCorner,
   }) {
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        return Offset(0, 0);
-      case TurnDirection.leftToRight:
-        return Offset(childWidth, 0);
+    late final double dx;
+    late final double dy;
+    if (turnCorner.isRight) {
+      dx = 0;
+    } else {
+      dx = childWidth;
     }
+    if (turnCorner.isTop) {
+      dy = 0;
+    } else {
+      dy = childHeight;
+    }
+    return Offset(dx, dy);
   }
 
   Offset calcFoldLowerCorner({
     required double childWidth,
     required double screenWidth,
-    required double height,
-    required TurnDirection direction,
+    required double screenHeight,
+    required TurnCorner turnCorner,
     required double animationTransitionPoint,
     required double animationProgress,
   }) {
     if (animationProgress <= animationTransitionPoint) {
       // animationProgressがanimationTransitionPointを超えない時、
       // foldLowerCornerはbottomCornerと一致する
-      return calcBottomCorner(
+      return calcOppositeCornerToFold(
         childWidth: childWidth,
-        height: height,
-        direction: direction,
+        childHeight: screenHeight,
+        turnCorner: turnCorner,
         animationTransitionPoint: animationTransitionPoint,
         animationProgress: animationProgress,
       );
@@ -81,28 +110,35 @@ class PageTurnClipperCalculator {
     final turnedPageBottomHorizontalDistance =
         screenWidth * turnedPageBottomWidthRatio;
 
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        return Offset(childWidth - turnedPageBottomHorizontalDistance, height);
-      case TurnDirection.leftToRight:
-        return Offset(turnedPageBottomHorizontalDistance, height);
+    late final double dx;
+    late final double dy;
+    if (turnCorner.isRight) {
+      dx = childWidth - turnedPageBottomHorizontalDistance;
+    } else {
+      dx = turnedPageBottomHorizontalDistance;
     }
+    if (turnCorner.isTop) {
+      dy = screenHeight;
+    } else {
+      dy = 0;
+    }
+    return Offset(dx, dy);
   }
 }
 
 class OverleafPainterCalculator {
-  Offset calcTopCorner({
+  Offset calcCornerToFold({
     required double screenWidth,
     required double turnedHorizontalDistance,
-    required double height,
-    required TurnDirection direction,
+    required double screenHeight,
+    required TurnCorner turnCorner,
     required double animationTransitionPoint,
     required double animationProgress,
   }) {
     if (animationProgress <= animationTransitionPoint) {
       final turnedPageHeightRatio =
           animationProgress / animationTransitionPoint;
-      final turnedPageVerticalDistance = height * turnedPageHeightRatio;
+      final turnedPageVerticalDistance = screenHeight * turnedPageHeightRatio;
 
       final W = turnedHorizontalDistance;
       final H = turnedPageVerticalDistance;
@@ -110,12 +146,19 @@ class OverleafPainterCalculator {
       final intersectionX = (W * H * H) / (W * W + H * H);
       final intersectionY = (W * W * H) / (W * W + H * H);
 
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          return Offset(screenWidth - 2 * intersectionX, 2 * intersectionY);
-        case TurnDirection.leftToRight:
-          return Offset(2 * intersectionX, 2 * intersectionY);
+      late final double dx;
+      late final double dy;
+      if (turnCorner.isRight) {
+        dx = screenWidth - 2 * intersectionX;
+      } else {
+        dx = 2 * intersectionX;
       }
+      if (turnCorner.isTop) {
+        dy = 2 * intersectionY;
+      } else {
+        dy = screenHeight - 2 * intersectionY;
+      }
+      return Offset(dx, dy);
     } else {
       final turnedPageBottomWidthRatio =
           (animationProgress - animationTransitionPoint) /
@@ -123,7 +166,7 @@ class OverleafPainterCalculator {
 
       // Alias that converts values to simple characters. -------
       final w2 = screenWidth * screenWidth;
-      final h2 = height * height;
+      final h2 = screenHeight * screenHeight;
       final q = animationProgress - turnedPageBottomWidthRatio;
       final q2 = q * q;
       // --------------------------------------------------------
@@ -132,29 +175,36 @@ class OverleafPainterCalculator {
       final intersectionX =
           screenWidth * h2 * animationProgress / (w2 * q2 + h2);
       final intersectionY =
-          w2 * height * animationProgress * q / (w2 * q2 + h2);
+          w2 * screenHeight * animationProgress * q / (w2 * q2 + h2);
 
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          return Offset(screenWidth - 2 * intersectionX, 2 * intersectionY);
-        case TurnDirection.leftToRight:
-          return Offset(2 * intersectionX, 2 * intersectionY);
+      late final double dx;
+      late final double dy;
+      if (turnCorner.isRight) {
+        dx = screenWidth - 2 * intersectionX;
+      } else {
+        dx = 2 * intersectionX;
       }
+      if (turnCorner.isTop) {
+        dy = 2 * intersectionY;
+      } else {
+        dy = screenHeight - 2 * intersectionY;
+      }
+      return Offset(dx, dy);
     }
   }
 
-  Offset calcBottomCorner({
+  Offset calcOppositeCornerToFold({
     required double screenWidth,
-    required double height,
-    required TurnDirection direction,
+    required double screenHeight,
+    required TurnCorner turnCorner,
     required double animationTransitionPoint,
     required double animationProgress,
   }) {
     if (animationProgress <= animationTransitionPoint) {
       return calcFoldLowerCorner(
         screenWidth: screenWidth,
-        height: height,
-        direction: direction,
+        screenHeight: screenHeight,
+        turnCorner: turnCorner,
         animationTransitionPoint: animationTransitionPoint,
         animationProgress: animationProgress,
       );
@@ -166,62 +216,79 @@ class OverleafPainterCalculator {
 
     // Alias that converts values to simple characters. -------
     final w2 = screenWidth * screenWidth;
-    final h2 = height * height;
+    final h2 = screenHeight * screenHeight;
     final q = animationProgress - turnedPageBottomWidthRatio;
     final q2 = q * q;
     // --------------------------------------------------------
 
     // Page corner position which is line target point of (W, 0) for the line connecting (W, 0) & (W, H).
     final intersectionX = screenWidth * h2 * animationProgress / (w2 * q2 + h2);
-    final intersectionY = w2 * height * animationProgress * q / (w2 * q2 + h2);
+    final intersectionY =
+        w2 * screenHeight * animationProgress * q / (w2 * q2 + h2);
 
     final intersectionCorrection = (animationProgress - q) / animationProgress;
 
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        return Offset(
-          screenWidth - 2 * intersectionX * intersectionCorrection,
-          2 * intersectionY * intersectionCorrection + height,
-        );
-      case TurnDirection.leftToRight:
-        return Offset(
-          2 * intersectionX * intersectionCorrection,
-          2 * intersectionY * intersectionCorrection + height,
-        );
+    late final double dx;
+    late final double dy;
+    if (turnCorner.isRight) {
+      dx = screenWidth - 2 * intersectionX * intersectionCorrection;
+    } else {
+      dx = 2 * intersectionX * intersectionCorrection;
     }
+    if (turnCorner.isTop) {
+      dy = 2 * intersectionY * intersectionCorrection + screenHeight;
+    } else {
+      dy = 0;
+    }
+    return Offset(dx, dy);
   }
 
   Offset calcFoldUpperCorner({
     required double screenWidth,
+    required double screenHeight,
     required double turnedHorizontalDistance,
-    required TurnDirection direction,
+    required TurnCorner turnCorner,
   }) {
-    switch (direction) {
-      case TurnDirection.rightToLeft:
-        return Offset(screenWidth - turnedHorizontalDistance, 0.0);
-      case TurnDirection.leftToRight:
-        return Offset(turnedHorizontalDistance, 0.0);
+    late final double dx;
+    late final double dy;
+    if (turnCorner.isRight) {
+      dx = screenWidth - turnedHorizontalDistance;
+    } else {
+      dx = turnedHorizontalDistance;
     }
+    if (turnCorner.isTop) {
+      dy = 0;
+    } else {
+      dy = screenHeight;
+    }
+    return Offset(dx, dy);
   }
 
   Offset calcFoldLowerCorner({
     required double screenWidth,
-    required double height,
-    required TurnDirection direction,
+    required double screenHeight,
+    required TurnCorner turnCorner,
     required double animationTransitionPoint,
     required double animationProgress,
   }) {
     if (animationProgress <= animationTransitionPoint) {
       final turnedPageHeightRatio =
           animationProgress / animationTransitionPoint;
-      final turnedPageVerticalDistance = height * turnedPageHeightRatio;
+      final turnedPageVerticalDistance = screenHeight * turnedPageHeightRatio;
 
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          return Offset(screenWidth, turnedPageVerticalDistance);
-        case TurnDirection.leftToRight:
-          return Offset(0.0, turnedPageVerticalDistance);
+      late final double dx;
+      late final double dy;
+      if (turnCorner.isRight) {
+        dx = screenWidth;
+      } else {
+        dx = 0;
       }
+      if (turnCorner.isTop) {
+        dy = turnedPageVerticalDistance;
+      } else {
+        dy = screenHeight - turnedPageVerticalDistance;
+      }
+      return Offset(dx, dy);
     } else {
       final turnedPageBottomWidthRatio =
           (animationProgress - animationTransitionPoint) /
@@ -229,12 +296,19 @@ class OverleafPainterCalculator {
 
       final turnedBottomWidth = screenWidth * turnedPageBottomWidthRatio;
 
-      switch (direction) {
-        case TurnDirection.rightToLeft:
-          return Offset(screenWidth - turnedBottomWidth, height);
-        case TurnDirection.leftToRight:
-          return Offset(turnedBottomWidth, height);
+      late final double dx;
+      late final double dy;
+      if (turnCorner.isRight) {
+        dx = screenWidth - turnedBottomWidth;
+      } else {
+        dx = turnedBottomWidth;
       }
+      if (turnCorner.isTop) {
+        dy = screenHeight;
+      } else {
+        dy = 0;
+      }
+      return Offset(dx, dy);
     }
   }
 }

--- a/lib/src/turn_page_transitions_builder.dart
+++ b/lib/src/turn_page_transitions_builder.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:turn_page_transition/src/turn_corner.dart';
 import 'package:turn_page_transition/src/turn_direction.dart';
 import 'package:turn_page_transition/src/turn_page_transition.dart';
 
 class TurnPageTransitionsBuilder extends PageTransitionsBuilder {
-  const TurnPageTransitionsBuilder({
+  TurnPageTransitionsBuilder({
     required this.overleafColor,
     @Deprecated('Use animationTransitionPoint instead') this.turningPoint,
     this.animationTransitionPoint,
+    @Deprecated("Use turnCorner instead")
     this.direction = TurnDirection.rightToLeft,
-  });
+    TurnCorner? startCorner,
+  }) : startCorner = startCorner ?? direction.toTurnCorner();
 
   final Color overleafColor;
 
@@ -21,8 +24,11 @@ class TurnPageTransitionsBuilder extends PageTransitionsBuilder {
   /// This value must be 0 <= animationTransitionPoint < 1.
   final double? animationTransitionPoint;
 
-  /// The direction in which the pages are turned.
+  @Deprecated("Use turnCorner instead")
   final TurnDirection direction;
+
+  /// The corner where the turn should start
+  final TurnCorner startCorner;
 
   @override
   Widget buildTransitions<T>(
@@ -38,7 +44,7 @@ class TurnPageTransitionsBuilder extends PageTransitionsBuilder {
       animation: animation,
       overleafColor: overleafColor,
       animationTransitionPoint: transitionPoint,
-      direction: direction,
+      startCorner: startCorner,
       child: child,
     );
   }

--- a/lib/src/turn_page_transitions_theme.dart
+++ b/lib/src/turn_page_transitions_theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:turn_page_transition/src/const.dart';
+import 'package:turn_page_transition/src/turn_corner.dart';
 import 'package:turn_page_transition/src/turn_direction.dart';
 import 'package:turn_page_transition/src/turn_page_transitions_builder.dart';
 
@@ -18,12 +19,14 @@ import 'package:turn_page_transition/src/turn_page_transitions_builder.dart';
 ///       home: HomePage(),
 ///  )
 class TurnPageTransitionsTheme extends PageTransitionsTheme {
-  const TurnPageTransitionsTheme({
+  TurnPageTransitionsTheme({
     this.overleafColor = defaultOverleafColor,
     @Deprecated('Use animationTransitionPoint instead') this.turningPoint,
     this.animationTransitionPoint,
+    @Deprecated("Use turnCorner instead")
     this.direction = TurnDirection.rightToLeft,
-  });
+    TurnCorner? startCorner,
+  }) : startCorner = startCorner ?? direction.toTurnCorner();
 
   /// The color of page backsides
   /// default Color is [Colors.grey]
@@ -38,13 +41,16 @@ class TurnPageTransitionsTheme extends PageTransitionsTheme {
   /// This value must be 0 <= animationTransitionPoint < 1.
   final double? animationTransitionPoint;
 
-  /// The direction in which the pages are turned.
+  @Deprecated("Use turnCorner instead")
   final TurnDirection direction;
+
+  /// The corner where the turn should start
+  final TurnCorner startCorner;
 
   PageTransitionsBuilder get _builder => TurnPageTransitionsBuilder(
         overleafColor: overleafColor,
         animationTransitionPoint: animationTransitionPoint ?? turningPoint,
-        direction: direction,
+        startCorner: startCorner,
       );
 
   @override

--- a/lib/turn_page_transition.dart
+++ b/lib/turn_page_transition.dart
@@ -10,4 +10,5 @@ export 'package:turn_page_transition/src/turn_page_view.dart'
     show TurnPageView, TurnPageController;
 export 'package:turn_page_transition/src/turn_direction.dart'
     show TurnDirection;
+export 'package:turn_page_transition/src/turn_corner.dart' show TurnCorner;
 export 'package:turn_page_transition/src/turn_page_transition_calc.dart';

--- a/test/page_turn_transition_test.dart
+++ b/test/page_turn_transition_test.dart
@@ -4,7 +4,6 @@ import 'package:turn_page_transition/turn_page_transition.dart';
 const screenWidth = 400.0;
 const screenHeight = 800.0;
 
-final directionCases = [TurnDirection.rightToLeft, TurnDirection.leftToRight];
 final animationTransitionPointCases = [0.3, 0.8];
 final animationProgressCases = [0.3, 0.8];
 
@@ -13,54 +12,53 @@ void main() {
   final oCalculator = OverleafPainterCalculator();
 
   group('PageTurnClipperCalculator tests', () {
-    directionCases.forEach((direction) {
+    TurnCorner.values.forEach((turnCorner) {
       animationTransitionPointCases.forEach((animationTransitionPoint) {
         animationProgressCases.forEach((animationProgress) {
           test(
               'Pattern:'
-              'direction: $direction,'
+              'turnCorner: $turnCorner,'
               'animationTransitionPoint: $animationTransitionPoint,'
               'animationProgress: $animationProgress', () {
             final childWidth = screenWidth * animationProgress;
 
             final pFoldUpperCorner = pCalculator.calcFoldUpperCorner(
               childWidth: childWidth,
-              direction: direction,
+              childHeight: screenHeight,
+              turnCorner: turnCorner,
             );
             final oFoldUpperCorner = oCalculator.calcFoldUpperCorner(
               screenWidth: screenWidth,
+              screenHeight: screenHeight,
               turnedHorizontalDistance: childWidth,
-              direction: direction,
+              turnCorner: turnCorner,
             );
 
             final pFoldLowerCorner = pCalculator.calcFoldLowerCorner(
               childWidth: childWidth,
               screenWidth: screenWidth,
-              height: screenHeight,
-              direction: direction,
+              screenHeight: screenHeight,
+              turnCorner: turnCorner,
               animationTransitionPoint: animationTransitionPoint,
               animationProgress: animationProgress,
             );
             final oFoldLowerCorner = oCalculator.calcFoldLowerCorner(
               screenWidth: screenWidth,
-              height: screenHeight,
-              direction: direction,
+              screenHeight: screenHeight,
+              turnCorner: turnCorner,
               animationTransitionPoint: animationTransitionPoint,
               animationProgress: animationProgress,
             );
 
-            switch (direction) {
-              case TurnDirection.rightToLeft:
-                final fix = screenWidth - childWidth;
-                expect(pFoldUpperCorner.dx + fix, oFoldUpperCorner.dx);
-                expect(pFoldUpperCorner.dy, oFoldUpperCorner.dy);
-                expect(pFoldLowerCorner.dx + fix, oFoldLowerCorner.dx);
-                expect(pFoldLowerCorner.dy, oFoldLowerCorner.dy);
-                break;
-              case TurnDirection.leftToRight:
-                expect(pFoldUpperCorner, oFoldUpperCorner);
-                expect(pFoldLowerCorner, oFoldLowerCorner);
-                break;
+            if (turnCorner.isRight) {
+              final fix = screenWidth - childWidth;
+              expect(pFoldUpperCorner.dx + fix, oFoldUpperCorner.dx);
+              expect(pFoldUpperCorner.dy, oFoldUpperCorner.dy);
+              expect(pFoldLowerCorner.dx + fix, oFoldLowerCorner.dx);
+              expect(pFoldLowerCorner.dy, oFoldLowerCorner.dy);
+            } else {
+              expect(pFoldUpperCorner, oFoldUpperCorner);
+              expect(pFoldLowerCorner, oFoldLowerCorner);
             }
           });
         });


### PR DESCRIPTION
First, thanks for your work, this lib is exactly the kind of animation I was looking for.
However, I would like the transition to take place from bottom right corner, so I tried to add this feature, as requested in https://github.com/Shoryu-Y/turn_page_transition/issues/10

This PR deprecates `TurnDirection` and creates `TurnCorner`, to choose the corner where the animation should start.
- `TurnCorner.topRight` equals to `TurnDirection.rightToLeft`

https://github.com/user-attachments/assets/4920089b-6426-4807-9e65-8d04f995d131


- `TurnCorner.topLeft` equals to `TurnDirection.leftToRight`

https://github.com/user-attachments/assets/7a4a1b22-95eb-4881-b2c8-add50c7786d7

- `TurnCorner.bottomRight` is new

https://github.com/user-attachments/assets/861ad8bc-71a0-4667-9f52-9d46208e6f06


- `TurnCorner.bottomLeft` is new

https://github.com/user-attachments/assets/45addfa5-6a26-4559-8811-d3f86249e051


⚠️ It seems to work pretty well, however `TurnPageView` doesn't work when the turnCorner is at the bottom of the screen (the screen stays blank in the example app). I don't understand why yet
